### PR TITLE
修复新版HA兼容性问题

### DIFF
--- a/custom_components/panel_iframe/__init__.py
+++ b/custom_components/panel_iframe/__init__.py
@@ -1,6 +1,7 @@
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.components.http import StaticPathConfig
+from homeassistant.components import frontend
 from homeassistant.components.panel_custom import async_register_panel
 import homeassistant.helpers.config_validation as cv
 import asyncio
@@ -12,19 +13,26 @@ VERSION = manifest.version
 
 CONFIG_SCHEMA = cv.deprecated(DOMAIN)
 
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.http.async_register_static_paths(
-        [ StaticPathConfig("/panel_iframe_www", hass.config.path("custom_components/" + DOMAIN + "/www"), False) ]
+        [
+            StaticPathConfig(
+                "/panel_iframe_www",
+                hass.config.path("custom_components/" + DOMAIN + "/www"),
+                False,
+            )
+        ]
     )
     # 添加面板
     cfg = entry.options
     url_path = entry.entry_id
     title = entry.title
-    mode = cfg.get('mode')
-    icon = cfg.get('icon')
-    url = cfg.get('url')
-    require_admin = cfg.get('require_admin')
-    proxy_access = cfg.get('proxy_access', False)
+    mode = cfg.get("mode")
+    icon = cfg.get("icon")
+    url = cfg.get("url")
+    require_admin = cfg.get("require_admin")
+    proxy_access = cfg.get("proxy_access", False)
 
     if url is not None:
         module_url = f"/panel_iframe_www/panel_iframe.js?v={VERSION}"
@@ -34,20 +42,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             proxy.register(hass.http.app.router)
             url = proxy.get_url()
 
-        await async_register_panel(hass,
+        await async_register_panel(
+            hass,
             frontend_url_path=url_path,
             webcomponent_name="ha-panel_iframe",
             sidebar_title=title,
             sidebar_icon=icon,
             module_url=module_url,
-            config={
-                'mode': mode,
-                'url': url
-            },
-            require_admin=require_admin
-          )
+            config={"mode": mode, "url": url},
+            require_admin=require_admin,
+        )
     entry.async_on_unload(entry.add_update_listener(update_listener))
     return True
+
 
 async def update_listener(hass, entry):
     """Handle options update."""
@@ -55,8 +62,9 @@ async def update_listener(hass, entry):
     await asyncio.sleep(1)
     await async_setup_entry(hass, entry)
 
+
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     url_path = entry.entry_id
-    hass.components.frontend.async_remove_panel(url_path)
+    frontend.async_remove_panel(hass, url_path)
     # 移除路由监听
     return True

--- a/custom_components/panel_iframe/config_flow.py
+++ b/custom_components/panel_iframe/config_flow.py
@@ -43,7 +43,8 @@ class SimpleConfigFlow(ConfigFlow, domain=manifest.domain):
 
 class OptionsFlowHandler(OptionsFlow):
     def __init__(self, config_entry: ConfigEntry):
-        self.config_entry = config_entry
+        super().__init__()
+        self._entry = config_entry
 
     async def async_step_init(self, user_input=None):
         return await self.async_step_user(user_input)
@@ -51,7 +52,7 @@ class OptionsFlowHandler(OptionsFlow):
     async def async_step_user(self, user_input=None):
         errors = {}
         if user_input is None:
-            options = self.config_entry.options
+            options = self._entry.options
             errors = {}
             DATA_SCHEMA = vol.Schema({
                 vol.Required("icon", default=options.get('icon', 'mdi:link-box-outline')): str,


### PR DESCRIPTION
修复了HA2026.3之后版本下
File "/config/custom_components/panel_iframe/config_flow.py", line 46, in __init__ self.config_entry = config_entry ^^^^^^^^^^^^^^^^^
AttributeError: property 'config_entry' of 'OptionsFlowHandler' object has no setter
和
hass.components.frontend.async_remove_panel(url_path) ^^^^^^^^^^^^^^^ 
AttributeError: 'HomeAssistant' object has no attribute 'components'
两处兼容性问题